### PR TITLE
Excluded known-devices policy from Bro conf

### DIFF
--- a/install/Raspbian/templates/local.bro.tpl
+++ b/install/Raspbian/templates/local.bro.tpl
@@ -51,7 +51,7 @@
 @load protocols/conn/known-hosts
 @load protocols/conn/known-services
 @load protocols/ssl/known-certs
-@load policy/misc/known-devices
+#@load policy/misc/known-devices
 
 # This script enables SSL/TLS certificate validation.
 @load protocols/ssl/validate-certs

--- a/install/Ubuntu/templates/local.bro.tpl
+++ b/install/Ubuntu/templates/local.bro.tpl
@@ -51,7 +51,7 @@
 @load protocols/conn/known-hosts
 @load protocols/conn/known-services
 @load protocols/ssl/known-certs
-@load policy/misc/known-devices
+#@load policy/misc/known-devices
 
 # This script enables SSL/TLS certificate validation.
 @load protocols/ssl/validate-certs


### PR DESCRIPTION
# Description

It seems that the policy "known-devices" it's not shipped with the latest Bro source code so I had to comment this line in the local.bro conf file to prevent the service from crashing.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
